### PR TITLE
[sc-9914] Upgrade mongomapper to 0.15.5 

### DIFF
--- a/joint.gemspec
+++ b/joint.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'wand', '~> 0.4'
   s.add_dependency 'mime-types'
-  s.add_dependency 'mongo_mapper', '~> 0.9'
+  s.add_dependency 'mongo_mapper', '~> 0.15'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/joint/attachment_proxy.rb
+++ b/lib/joint/attachment_proxy.rb
@@ -36,7 +36,7 @@ module Joint
     alias_method :blank?, :nil?
 
     def grid_io
-      @grid_io ||= @instance.grid.get(id)
+      @grid_io ||= @instance.grid.open_download_stream(id)
     end
 
     def method_missing(method, *args, &block)

--- a/lib/joint/instance_methods.rb
+++ b/lib/joint/instance_methods.rb
@@ -1,6 +1,6 @@
 module Joint
   def grid
-    @grid ||= Mongo::Grid.new(database, joint_collection_name)
+    @grid ||= database.fs(bucket_name: joint_collection_name)
   end
 
   private
@@ -17,13 +17,15 @@ module Joint
       assigned_attachments.each_pair do |name, io|
         next unless io.respond_to?(:read)
         io.rewind if io.respond_to?(:rewind)
-        grid.delete(send(name).id)
-        grid.put(io, {
-          :_id          => send(name).id,
-          :filename     => send(name).name,
-          :content_type => send(name).type,
-          :w            => 0
-        })
+        delete_file(send(name).id)
+        grid.upload_from_stream(
+          send(name).name,
+          io,
+          {
+            file_id: send(name).id,
+            metadata: { content_type: send(name).type },
+          }
+        )
       end
       assigned_attachments.clear
     end
@@ -39,13 +41,24 @@ module Joint
 
     def destroy_nil_attachments
       nil_attachments.each_value do |id|
-        grid.delete(id)
+        delete_file(id)
       end
 
       nil_attachments.clear
     end
 
     def destroy_all_attachments
-      self.class.attachment_names.map { |name| grid.delete(send(name).id) }
+      self.class.attachment_names.map do |name|
+        delete_file(send(name).id)
+      end
+    end
+
+    def delete_file(file_id)
+      file_id = BSON::ObjectId(file_id) if file_id.is_a?(String)
+      begin
+        grid.delete(file_id)
+      rescue Mongo::Error::FileNotFound => e
+        Rails.logger.warn(e.message)
+      end
     end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -103,7 +103,7 @@ module JointTestHelpers
 
   def grid(collection_name = 'fs')
     @grids ||= {}
-    @grids[collection_name] ||= Mongo::Grid.new(MongoMapper.database, collection_name)
+    @grids[collection_name] ||= MongoMapper.database.fs(bucket_name: collection_name)
   end
 
   def key_names


### PR DESCRIPTION
Upgrade MongoMapper to version 0.15.5. Upgrade mongo to 2.16. The most recent version of mongo is 2.17, but that version drops support for our mongo db version. v2.16 will allow us to upgrade our db version to the most recent version at which point we can upgrade the mongo gem. Remove deprecated `github` gem location in favor of `git`.

The following PRs are dependent this PRs:
https://github.com/Punchbowl/mypunchbowl.com/pull/1075
https://github.com/Punchbowl/punchbowl-core/pull/430
https://github.com/Punchbowl/punchbowl-cards/pull/164