### PR TITLE
[sc-12464] Support clearing attachments with any blank value instead …

### DIFF
--- a/lib/joint/class_methods.rb
+++ b/lib/joint/class_methods.rb
@@ -38,7 +38,7 @@ module Joint
       unless options[:readonly]
         self.class_eval <<-EOC
           def #{accessor_name}=(file)
-            if file.nil?
+            if file.blank?
               nil_attachments[:#{name}] = send("#{name}_id")
               assigned_attachments.delete(:#{name})
             else


### PR DESCRIPTION
### Description

Allow deleting attachments with any blank value instead of only `nil` values. Prior to this change `item.accessor_name = ''` would result in an error. As part of https://github.com/Punchbowl/mypunchbowl.com/pull/1124 we are sometimes passing data to the API via JS as `FormData` in order to support file uploads. However, `FormData` doesn't support `null` vaules, only strings and files. Allowing empty strings to clear attachments will allow the API to receive empty strings without conditionally converting to `nil`

Relates to [sc-12464](https://app.shortcut.com/punchbowl/story/12464)

Type of Change: new feature
