### PR TITLE
[sc-13849] Use content_type key instead of metadata object. Docs say …

### DIFF
--- a/lib/joint/instance_methods.rb
+++ b/lib/joint/instance_methods.rb
@@ -22,8 +22,8 @@ module Joint
           send(name).name,
           io,
           {
+            content_type: send(name).type,
             file_id: send(name).id,
-            metadata: { content_type: send(name).type },
           }
         )
       end


### PR DESCRIPTION
…content_type is deprecated, but using the metadata object results in type being binary/octet-stream instead of image/png when requesting the file