### PR TITLE
Make cloned documents safe to attach files to

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'bson_ext', :require => false
 gem 'mocha'
 gem 'byebug'
+# The suite is written in minitest/spec's "must_equal on any object" style, which
+# Minitest 6 no longer installs onto Object.
+gem 'minitest', '~> 5.0'

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ require 'rake/testtask'
 Rake::TestTask.new do |test|
   test.libs      << 'lib' << 'test'
   test.pattern   = 'test/**/test_*.rb'
-  test.ruby_opts = ['-rubygems']
   test.verbose   = true
 end
 

--- a/lib/joint/instance_methods.rb
+++ b/lib/joint/instance_methods.rb
@@ -3,6 +3,45 @@ module Joint
     @grid ||= database.fs(bucket_name: joint_collection_name)
   end
 
+  # An AttachmentProxy holds a reference to the record it was built from and reads
+  # `<name>_id` off it, and the pending-upload bookkeeping is shared by reference after
+  # a clone. Neither may survive a copy: left in place, the copy's `save_attachments`
+  # deletes and rewrites the *source's* GridFS files while the copy's own ids point at
+  # nothing.
+  def initialize_copy(other)
+    super
+
+    instance_variables.each do |ivar|
+      remove_instance_variable(ivar) if instance_variable_get(ivar).is_a?(AttachmentProxy)
+    end
+
+    @assigned_attachments = nil
+    @nil_attachments      = nil
+    @grid                 = nil
+  end
+
+  # Detach this record from the GridFS files it inherited from the record it was copied
+  # from, so that saving uploads its own. Detaches every attachment unless given names.
+  #
+  # The attachment writers mint a new id only when the current one is nil, which is what
+  # makes replacing a file in place work -- and what makes a copy silently overwrite its
+  # source. This clears the ids so the next assignment gets fresh ones.
+  #
+  # Deliberately writes the plain `<name>_id/_name/_size/_type` keys rather than going
+  # through the attachment writers: `send(:"#{name}=", nil)` would register the old ids
+  # in `nil_attachments`, and the after_save `destroy_nil_attachments` would then delete
+  # the source's files outright.
+  def detach_attachments!(*names)
+    names = self.class.attachment_names.to_a if names.empty?
+
+    names.map(&:to_sym).each do |name|
+      send(:"#{name}_id=",   nil)
+      send(:"#{name}_name=", nil)
+      send(:"#{name}_size=", nil)
+      send(:"#{name}_type=", nil)
+    end
+  end
+
   private
     def assigned_attachments
       @assigned_attachments ||= {}
@@ -58,7 +97,9 @@ module Joint
       begin
         grid.delete(file_id)
       rescue Mongo::Error::FileNotFound => e
-        Rails.logger.warn(e.message)
+        # Joint does not depend on Rails; outside of it (including this gem's own test
+        # suite) there is no Rails.logger to warn through.
+        Rails.logger.warn(e.message) if defined?(Rails) && Rails.respond_to?(:logger)
       end
     end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ require 'mongo_mapper'
 require 'minitest/spec'
 require 'minitest/autorun'
 require 'minitest/pride'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require File.expand_path(File.dirname(__FILE__) + '/../lib/joint')
 
@@ -16,7 +16,7 @@ MongoMapper.database = "joint_test"
 
 class Minitest::Test
   def setup
-    MongoMapper.database.collections.each { |coll| coll.remove unless coll.name =~ /^system/ }
+    MongoMapper.database.collections.each { |coll| coll.delete_many unless coll.name =~ /^system/ }
   end
 
   def assert_difference(expression, difference = 1, message = nil, &block)

--- a/test/test_joint.rb
+++ b/test/test_joint.rb
@@ -614,4 +614,87 @@ describe "JointTest" do
       end
     end
   end
+
+  describe "Cloning a document with attachments" do
+    before do
+      @doc = Asset.create(:image => @image, :file => @file)
+      rewind_files
+    end
+
+    it "does not hand the clone a proxy bound to the source" do
+      @doc.image # memoize the proxy on the source, as any copy routine that reads it would
+
+      copy = @doc.clone
+      copy.image_id = BSON::ObjectId.new
+
+      copy.image.wont_be_same_as @doc.image
+      copy.image.id.must_equal copy.image_id
+      copy.image.id.wont_equal @doc.image_id
+    end
+
+    it "does not share pending attachment bookkeeping with the source" do
+      copy = @doc.clone
+
+      copy.send(:assigned_attachments).wont_be_same_as @doc.send(:assigned_attachments)
+      copy.send(:nil_attachments).wont_be_same_as @doc.send(:nil_attachments)
+    end
+
+    it "clears every attachment key on detach_attachments!" do
+      copy = @doc.clone
+      copy.detach_attachments!
+
+      Asset.attachment_names.each do |name|
+        key_names.each { |key| copy.send("#{name}_#{key}").must_be_nil }
+      end
+    end
+
+    it "clears only the named attachments on detach_attachments!" do
+      copy = @doc.clone
+      copy.detach_attachments!(:image)
+
+      copy.image_id.must_be_nil
+      copy.file_id.must_equal @doc.file_id
+    end
+
+    it "uploads its own files rather than overwriting the source's" do
+      original_id    = @doc.image_id
+      original_bytes = @doc.image.read
+
+      copy = @doc.clone
+      copy.detach_attachments!
+      copy.image = @image
+      copy.file  = @file
+
+      # 2 new grid files, not 0: overwriting the source in place would net out to zero.
+      assert_grid_difference(2) { copy.save! }
+      rewind_files
+
+      copy.image_id.wont_equal original_id
+      Asset.find(copy.id).image.read.must_equal original_bytes
+      Asset.find(@doc.id).image_id.must_equal original_id
+      Asset.find(@doc.id).image.read.must_equal original_bytes
+    end
+
+    it "uploads its own files when the clone is an embedded document" do
+      asset = Asset.new
+      doc   = asset.embedded_assets.build(:image => @image, :file => @file)
+      asset.save!
+      rewind_files
+
+      doc.image # memoize the proxy on the source
+
+      copy = doc.clone
+      copy.detach_attachments!
+      copy.image = @image
+
+      assert_grid_difference(1) do
+        asset.embedded_assets << copy
+        asset.save!
+      end
+      rewind_files
+
+      copy.image_id.wont_equal doc.image_id
+      Asset.find(asset.id).embedded_assets.last.image.read.must_equal doc.image.read
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Copying a MongoMapper document that has Joint attachments corrupts the source.

`Joint::ClassMethods#attachment` generates `@image ||= AttachmentProxy.new(self, :image)`, and the proxy holds a reference to the record it was built from — it reads `<name>_id` / `_name` / `_type` off that instance. Ruby's `clone` copies instance variables, and MongoMapper's `initialize_copy` only resets `_id` and association ivars, so a clone of a record that had ever read an attachment gets a proxy still bound to the **source**.

`save_attachments` then runs `delete_file(send(name).id)` + `upload_from_stream(..., file_id: send(name).id)` against the source's id: it deletes the source's GridFS file, writes the copy's bytes there, and leaves the copy's own `<name>_id` pointing at nothing.

`@assigned_attachments` and `@nil_attachments` are the same Hash objects after a clone, so `assigned_attachments.clear` at the end of `save_attachments` also wipes the other record's pending uploads.

This is how Punchbowl's "copy design template" admin action started producing templates with a 404ing card image, and silently rewrote the source template's blob in the process.

## Changes

**`Joint#initialize_copy`** — drops the memoized `AttachmentProxy` ivars and the pending-upload bookkeeping, so a clone gets its own. Matches on `AttachmentProxy` rather than on `attachment_names` because the memo ivar is named after `accessor_name`, which `attachment` accepts as an option and does not record.

**`Joint#detach_attachments!(*names)`** — the second half of the problem. The attachment writers mint a new id only when the current one is `nil`, which is what makes replace-in-place work — and what makes a copy overwrite its source even with a correctly bound proxy. Callers copying a record call this before assigning new files. With no arguments it detaches every attachment, which covers Roachclip-derived styles for free since Roachclip registers each style as its own Joint attachment.

It deliberately writes the plain `<name>_id/_name/_size/_type` keys rather than `send(:"#{name}=", nil)`: the writer would register the old ids in `nil_attachments` and the after_save `destroy_nil_attachments` would delete the source's files outright.

## Test suite

The suite could not run at all, so this also unbreaks it:

- `bson_ext` was folded into `bson` years ago and its C extension no longer builds — dropped from the Gemfile
- `-rubygems` in the Rakefile is a Ruby 1.8 flag
- `mocha/mini_test` → `mocha/minitest`
- `Collection#remove` is not in the 2.x driver → `delete_many`
- Minitest 6 no longer installs `must_equal` onto Object; pinned to `~> 5.0` since the suite is written in that style
- `delete_file`'s rescue called `Rails.logger` unconditionally, but the gem does not depend on Rails — every test errored on it

Baseline before this branch: `76 runs, 1 failures, 12 errors`. After: `82 runs, 1 failures, 12 errors`. The 13 remaining are pre-existing and all live in the tests, not the library — they call Mongo driver 1.x APIs (`grid.get`, `Mongo::Grid.any_instance`, `files_id`, `Mongo::GridFileNotFound`). Left alone here.

The 6 new tests all fail on master and pass on this branch. Note the suite talks to a mongod on `localhost:27017` (database `joint_test`).